### PR TITLE
Initial support windows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     provided "org.embulk:embulk-core:0.7.0"
     // compile "YOUR_JAR_DEPENDENCY_GROUP:YOUR_JAR_DEPENDENCY_MODULE:YOUR_JAR_DEPENDENCY_VERSION"
     testCompile "junit:junit:4.+"
+    testCompile 'org.embulk:embulk-core:0.7.+:tests'
 }
 
 task classpath(type: Copy, dependsOn: ["jar"]) {

--- a/src/main/java/org/embulk/output/CommandFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/CommandFileOutputPlugin.java
@@ -77,6 +77,25 @@ public class CommandFileOutputPlugin
         return new PluginFileOutput(cmdline, taskIndex);
     }
 
+    private static class ShellFactory
+    {
+        private List<String> shell;
+
+        public List<String> get() {
+            return this.shell;
+        }
+
+        public ShellFactory build() {
+            String osName = System.getProperty("os.name");
+            if(osName.contains("Windows")) {
+                this.shell = ImmutableList.of("PowerShell.exe", "-Command");
+            } else {
+                this.shell = ImmutableList.of("sh", "-c");
+            }
+            return this;
+        }
+    }
+
     private static class ProcessWaitOutputStream
             extends FilterOutputStream
     {

--- a/src/main/java/org/embulk/output/CommandFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/CommandFileOutputPlugin.java
@@ -5,6 +5,8 @@ import java.util.ArrayList;
 import java.io.OutputStream;
 import java.io.FilterOutputStream;
 import java.io.IOException;
+
+import com.google.common.annotations.VisibleForTesting;
 import org.slf4j.Logger;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
@@ -73,7 +75,8 @@ public class CommandFileOutputPlugin
         return new PluginFileOutput(cmdline, taskIndex);
     }
 
-    private static class ShellFactory
+    @VisibleForTesting
+    static class ShellFactory
     {
         private List<String> shell;
 

--- a/src/main/java/org/embulk/output/CommandFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/CommandFileOutputPlugin.java
@@ -86,7 +86,7 @@ public class CommandFileOutputPlugin
 
         public ShellFactory build() {
             String osName = System.getProperty("os.name");
-            if(osName.contains("Windows")) {
+            if(osName.indexOf("Windows") >= 0) {
                 this.shell = ImmutableList.of("PowerShell.exe", "-Command");
             } else {
                 this.shell = ImmutableList.of("sh", "-c");

--- a/src/main/java/org/embulk/output/CommandFileOutputPlugin.java
+++ b/src/main/java/org/embulk/output/CommandFileOutputPlugin.java
@@ -32,11 +32,6 @@ public class CommandFileOutputPlugin
         public String getCommand();
     }
 
-    public static final List<String> SHELL = ImmutableList.of(
-        // TODO use ["PowerShell.exe", "-Command"] on windows?
-        "sh", "-c"
-    );
-
     @Override
     public ConfigDiff transaction(ConfigSource config, int taskCount,
             FileOutputPlugin.Control control)
@@ -68,8 +63,9 @@ public class CommandFileOutputPlugin
     {
         PluginTask task = taskSource.loadTask(PluginTask.class);
 
+        List<String> shell = new ShellFactory().build().get();
         List<String> cmdline = new ArrayList<String>();
-        cmdline.addAll(SHELL);
+        cmdline.addAll(shell);
         cmdline.add(task.getCommand());
 
         logger.info("Using command {}", cmdline);

--- a/src/test/java/org/embulk/output/TestCommandFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/TestCommandFileOutputPlugin.java
@@ -29,7 +29,7 @@ public class TestCommandFileOutputPlugin
         List<String> shell = shellFactory.get();
         String osName = System.getProperty("os.name");
         List<String> actualShellCmd;
-        if (osName.contains("Windows")) {
+        if (osName.indexOf("Windows") >= 0) {
             actualShellCmd = ImmutableList.of("PowerShell.exe", "-Command");
         } else {
             actualShellCmd = ImmutableList.of("sh", "-c");

--- a/src/test/java/org/embulk/output/TestCommandFileOutputPlugin.java
+++ b/src/test/java/org/embulk/output/TestCommandFileOutputPlugin.java
@@ -1,5 +1,39 @@
 package org.embulk.output;
 
+import com.google.common.collect.ImmutableList;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.embulk.EmbulkTestRuntime;
+import org.embulk.output.CommandFileOutputPlugin.ShellFactory;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
 public class TestCommandFileOutputPlugin
 {
+    @Rule
+    public EmbulkTestRuntime runtime = new EmbulkTestRuntime();
+
+    private ShellFactory shellFactory;
+
+    @Before
+    public void createResources()
+    {
+        shellFactory = new ShellFactory().build();
+    }
+
+    @Test
+    public void testShell() {
+        List<String> shell = shellFactory.get();
+        String osName = System.getProperty("os.name");
+        List<String> actualShellCmd;
+        if (osName.contains("Windows")) {
+            actualShellCmd = ImmutableList.of("PowerShell.exe", "-Command");
+        } else {
+            actualShellCmd = ImmutableList.of("sh", "-c");
+        }
+        assertEquals(actualShellCmd, shell);
+    }
 }


### PR DESCRIPTION
I've written patches to support Windows!

Let's cut out Windows support feature!!!

For PowerShell config is like this:

``` yaml
out:
  type: command
  command: ${input} > task.${Env:INDEX}.${Env:SEQID}.csv
  formatter:
    type: csv
```

It works as below:

``` log
2015-09-11 17:51:20.873 +0900: Embulk v0.7.4
2015-09-11 17:51:23.197 +0900 [INFO] (transaction): Loaded plugin embulk-output-command (0.1.3)
2015-09-11 17:51:23.244 +0900 [INFO] (transaction): Listing local files at directory 'C:\Users\hatake-moz\embulk-output-
command\try1\csv' filtering filename by prefix 'sample_'
2015-09-11 17:51:23.244 +0900 [INFO] (transaction): Loading files [C:\Users\hatake-moz\embulk-output-command\try1\csv\sa
mple_01.csv.gz]
2015-09-11 17:51:23.369 +0900 [INFO] (transaction): {done:  0 / 1, running: 0}
2015-09-11 17:51:23.369 +0900 [INFO] (task-0000): Using command [PowerShell.exe, -Command, ${input} > task.${Env:INDEX}.
${Env:SEQID}.csv]
2015-09-11 17:51:23.790 +0900 [INFO] (transaction): {done:  1 / 1, running: 0}
2015-09-11 17:51:23.837 +0900 [INFO] (main): Committed.
2015-09-11 17:51:23.837 +0900 [INFO] (main): Next config diff: {"in":{"last_path":"C:\\Users\\hatake-moz\\embulk-output-
command\\try1\\csv\\sample_01.csv.gz"},"out":{}} 

PS> Get-Content .\task.0.0.csv
id,account,time,purchase,comment
1,32864,2015-01-27 19:23:49.000000 +0000,2015-01-27 00:00:00.000000 +0000,embulk
2,14824,2015-01-27 19:01:23.000000 +0000,2015-01-27 00:00:00.000000 +0000,embulk jruby
3,27559,2015-01-28 02:20:02.000000 +0000,2015-01-28 00:00:00.000000 +0000,"Embulk ""csv"" parser plugin"
4,11270,2015-01-29 11:54:36.000000 +0000,2015-01-29 00:00:00.000000 +0000,NULL 
```
